### PR TITLE
Resolve false positive json parsing of ENVs

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,9 @@
       }
     },
     "supportedProtocols": [
-      "ibmmq","kafka","kafka-secure"
+      "ibmmq",
+      "kafka",
+      "kafka-secure"
     ],
     "nonRenderableFiles": [
       "style.css",

--- a/test/Common.test.js
+++ b/test/Common.test.js
@@ -152,18 +152,17 @@ test('EnvJson extracts correct values', async () => {
   const generator = new Generator(path.normalize('./'), OUTPUT_DIR, { forceWrite: true, templateParams: params });
   await generator.generateFromFile(path.resolve('test', yaml));
   
-  expect(testCommon.EnvJson({asyncapi: generator.asyncapi, params: generator.templateParams})).toBe(`
-  {
-    "MQ_ENDPOINTS": [{
-      "HOST": "localhost",
-      "PORT": "1414",
-      "CHANNEL": "DEV.APP.SVRCONN",
-      "QMGR": "QM1",
-      "APP_USER": "app",
-      "APP_PASSWORD": "passw0rd"
+  const generatedJson = JSON.stringify(JSON.parse(testCommon.EnvJson({asyncapi: generator.asyncapi, params: generator.templateParams})));
+  const expectedJson = JSON.stringify({
+    MQ_ENDPOINTS: [{
+      HOST: 'localhost',
+      PORT: '1414',
+      CHANNEL: 'DEV.APP.SVRCONN',
+      QMGR: 'QM1',
+      APP_USER: 'app',
+      APP_PASSWORD: 'passw0rd'
     }]
-  }
-  `);
+  });
 });
 
 // Test ImportModels


### PR DESCRIPTION
The `EnvJson extracts correct values` test current fails due to incorrect indenting. This improvement parses and re-stringifies the real and expected JSON so the outputs are white-space insensitive. 